### PR TITLE
compute_driver missing in nova.conf

### DIFF
--- a/roles/ceilometer/tasks/ceilometer-nova.yml
+++ b/roles/ceilometer/tasks/ceilometer-nova.yml
@@ -11,11 +11,6 @@
   template: src={{ item }}.j2 dest=/etc/ceilometer/{{ item }}
   with_items:
     - ceilometer.conf
-
-- name: install configuration
-  tags: config
-  copy: src={{ item }} dest=/etc/ceilometer/{{ item }}
-  with_items:
     - pipeline.yaml
 
 - name: start services

--- a/roles/ceilometer/tasks/controller.yml
+++ b/roles/ceilometer/tasks/controller.yml
@@ -40,11 +40,6 @@
   template: src={{ item }}.j2 dest=/etc/ceilometer/{{ item }}
   with_items:
     - ceilometer.conf
-
-- name: install configuration
-  tags: config
-  copy: src={{ item }} dest=/etc/ceilometer/{{ item }}
-  with_items:
     - pipeline.yaml
 
 - name: start services

--- a/roles/ceilometer/templates/pipeline.yaml.j2
+++ b/roles/ceilometer/templates/pipeline.yaml.j2
@@ -1,0 +1,92 @@
+---
+sources:
+    - name: meter_source
+      interval: 600
+      meters:
+          - "*"
+      sinks:
+          - meter_sink
+    - name: cpu_source
+      interval: 600
+      meters:
+          - "cpu"
+      sinks:
+          - cpu_sink
+          - cpu_delta_sink
+    - name: disk_source
+      interval: 600
+      meters:
+          - "disk.read.bytes"
+          - "disk.read.requests"
+          - "disk.write.bytes"
+          - "disk.write.requests"
+          - "disk.device.read.bytes"
+          - "disk.device.read.requests"
+          - "disk.device.write.bytes"
+          - "disk.device.write.requests"
+      sinks:
+          - disk_sink
+    - name: network_source
+      interval: 600
+      meters:
+          - "network.incoming.bytes"
+          - "network.incoming.packets"
+          - "network.outgoing.bytes"
+          - "network.outgoing.packets"
+      sinks:
+          - network_sink
+sinks:
+    - name: meter_sink
+      transformers:
+      publishers:
+          - notifier://
+    - name: cpu_sink
+      transformers:
+          - name: "rate_of_change"
+            parameters:
+                target:
+                    name: "cpu_util"
+                    unit: "%"
+                    type: "gauge"
+                    scale: "100.0 / (10**9 * (resource_metadata.cpu_number or 1))"
+      publishers:
+          - notifier://
+    - name: cpu_delta_sink
+      transformers:
+          - name: "delta"
+            parameters:
+                target:
+                    name: "cpu.delta"
+                growth_only: True
+      publishers:
+          - notifier://
+    - name: disk_sink
+      transformers:
+          - name: "rate_of_change"
+            parameters:
+                source:
+                    map_from:
+                        name: "(disk\\.device|disk)\\.(read|write)\\.(bytes|requests)"
+                        unit: "(B|request)"
+                target:
+                    map_to:
+                        name: "\\1.\\2.\\3.rate"
+                        unit: "\\1/s"
+                    type: "gauge"
+      publishers:
+          - notifier://
+    - name: network_sink
+      transformers:
+          - name: "rate_of_change"
+            parameters:
+                source:
+                   map_from:
+                       name: "network\\.(incoming|outgoing)\\.(bytes|packets)"
+                       unit: "(B|packet)"
+                target:
+                    map_to:
+                        name: "network.\\1.\\2.rate"
+                        unit: "\\1/s"
+                    type: "gauge"
+      publishers:
+          - notifier://

--- a/roles/nova/templates/nova.conf.j2
+++ b/roles/nova/templates/nova.conf.j2
@@ -12,6 +12,7 @@ network_api_class = nova.network.neutronv2.api.API
 security_group_api = neutron
 linuxnet_interface_driver = nova.network.linux_net.NeutronLinuxBridgeInterfaceDriver
 firewall_driver = nova.virt.firewall.NoopFirewallDriver
+compute_driver=libvirt.LibvirtDriver
 
 enabled_apis=osapi_compute,metadata
 


### PR DESCRIPTION
There is computer_driver option is missing in nova.conf, Have added the option for the same, So that instance creation is not at all working fine it keeps on failing, Now added the compute_driver option so that it is working fine now.
